### PR TITLE
Add the repository field to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.4.3"
 edition = "2018"
 description = "A crate that provides functionality for creating context"
 license = "MIT"
+repository = "https://github.com/matthewrobertbell/mkcontext"
 
 [dependencies]
 clap = { version = "4.0", features = ["derive"] }


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.